### PR TITLE
Fix init command on Windows

### DIFF
--- a/src/main/java/fr/insalyon/citi/golo/cli/command/InitCommand.java
+++ b/src/main/java/fr/insalyon/citi/golo/cli/command/InitCommand.java
@@ -122,7 +122,7 @@ public class InitCommand implements CliCommand {
   }
 
   private void mkdir(File directory) throws IOException {
-    if (!directory.mkdir()) {
+    if (!directory.mkdirs()) {
       throw new IOException("[error] Unable to create directory " + directory + ".");
     }
   }


### PR DESCRIPTION
After reading your blog post, I wanted to help you simplify your Gradle build some more (especially since you wanted it to be more declarative).

I tried running the tests on Windows and they failed because of a small bug in the Init Command.